### PR TITLE
Use dashboard icon for homepage thumbnail

### DIFF
--- a/content/post/2026/2026-06-01_Geocoding_Credit_Dashboard.md
+++ b/content/post/2026/2026-06-01_Geocoding_Credit_Dashboard.md
@@ -5,7 +5,7 @@ date: 2026-06-01
 
 autoThumbnailImage: false
 thumbnailImagePosition: "left"
-thumbnailImage: https://res.cloudinary.com/wessport/image/upload/v1780429571/blog/2026/geocoding-credit-dashboard-cover.jpg
+thumbnailImage: https://res.cloudinary.com/wessport/image/upload/v1780535731/blog/2026/noun-dashboard.png
 coverImage: https://res.cloudinary.com/wessport/image/upload/v1780429571/blog/2026/geocoding-credit-dashboard-cover.jpg
 metaAlignment: center
 coverMeta: in


### PR DESCRIPTION
## Summary
- upload noun-dashboard.png to Cloudinary
- use the dashboard icon as the homepage thumbnail for the latest post
- keep the existing cover photo on the post page

## Verification
- hugo
- verified public/index.html references noun-dashboard.png